### PR TITLE
Add storage privileges to workaround #14

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -13,6 +13,9 @@
     "default_locale": "en",
     "type": "privileged",
     "permissions": {
+            "storage": {
+            "description": "Avoid IndexedDB quota Warning"
+        },
         "systemXHR": {
             "description": "Required to download CrossWire's bible modules"
         }


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=827740#c13
apps can opt-in for unlimited indexedDB until https://bugzilla.mozilla.org/show_bug.cgi?id=1048696
is fixed